### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/ppx_variants_conv.opam
+++ b/ppx_variants_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"        {>= "v0.14" & < "v0.15"}
   "variantslib" {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.11.0"}
+  "ppxlib"      {>= "0.14.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/src/ppx_variants_conv.ml
+++ b/src/ppx_variants_conv.ml
@@ -229,7 +229,7 @@ module Gen_sig = struct
     [ psig_module ~loc
         (module_declaration
            ~loc
-           ~name:(Located.mk ~loc (variants_module ty_name))
+           ~name:(Located.mk ~loc (Some (variants_module ty_name)))
            ~type_:(pmty_signature ~loc
                      (variant_defs @ [ v_fold_fun ~variant_type loc variants
                                      ; v_iter_fun ~variant_type loc variants
@@ -474,7 +474,7 @@ module Gen_str = struct
     [ pstr_module ~loc
         (module_binding
            ~loc
-           ~name:(Located.mk ~loc (variants_module variant_name))
+           ~name:(Located.mk ~loc (Some (variants_module variant_name)))
            ~expr:(pmod_structure ~loc
                     (variants @ [ v_fold_fun loc ty
                                 ; v_iter_fun loc ty


### PR DESCRIPTION
The next release of ppxlib will use the 4.10 AST internally. This PR makes ppx_variants_conv compatible with this new version. Probably worth waiting for the new release before merging this!