### PR TITLE
Adapt to Ppxlib's API change

### DIFF
--- a/ppx_variants_conv.opam
+++ b/ppx_variants_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"        {>= "v0.14" & < "v0.15"}
   "variantslib" {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.14.0"}
+  "ppxlib"      {>= "0.23.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/src/ppx_variants_conv.ml
+++ b/src/ppx_variants_conv.ml
@@ -66,7 +66,7 @@ end
 
 let variant_name_to_string v =
   let s = String.lowercase v in
-  if Caml.Hashtbl.mem Lexer.keyword_table s
+  if Keyword.is_keyword s
   then s ^ "_"
   else s
 


### PR DESCRIPTION
Ppxlib is removing `Lexer.keyword_table` from the API in exchange for the more lightweight `Keyword.is_keyword`. See [this PR](https://github.com/ocaml-ppx/ppxlib/pull/227). This commit adapts ppx_variants_conv to that change.

It would be good to merge this PR when ppxlib 0.23.0 gets released. I'll notify here when that happens.